### PR TITLE
Add configurable option to set values on all content that would match the executing rule.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,3 +6,7 @@ Changelog
 
 - Initial release.
   [instification]
+
+- Add configurable option to set values on all content that would match the 
+  executing rule.
+  [instification]

--- a/collective/contentrules/setfield/action.py
+++ b/collective/contentrules/setfield/action.py
@@ -33,6 +33,7 @@ class SetFieldAction(SimpleItem):
     """
     implements(ISetFieldAction, IRuleElementData)
     value_script = ""
+    update_all = ""
     element = "collective.contentrules.setfield.ApplySetField"
 
     @property
@@ -55,7 +56,7 @@ class SetFieldActionExecutor(object):
     def __call__(self):
         self.obj = self.event.object
         self.value_script = getattr(self.element, 'value_script', False)
-        self.update_all = getattr(self.element, 'update_all_content', False)
+        self.update_all = getattr(self.element, 'update_all', False)
         self.conditions = self.get_conditions()
         self.portal = api.portal.get()
 

--- a/collective/contentrules/setfield/action.py
+++ b/collective/contentrules/setfield/action.py
@@ -3,6 +3,7 @@ from logging import getLogger
 
 
 from OFS.SimpleItem import SimpleItem
+from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import utils
 from Products.statusmessages.interfaces import IStatusMessage
 from collective.contentrules.setfield import SetFieldMessageFactory as _
@@ -11,11 +12,16 @@ from collective.contentrules.setfield.restricted import PyScript
 
 from plone.app.contentrules.browser.formhelper import AddForm
 from plone.app.contentrules.browser.formhelper import EditForm
-
+from plone import api
 from plone.contentrules.rule.interfaces import IExecutable
 from plone.contentrules.rule.interfaces import IRuleElementData
+from plone.contentrules.engine.interfaces import IRuleStorage
+from plone.uuid.interfaces import IUUID
 from zope.component import adapts
+from zope.component import getMultiAdapter
+from zope.component import queryUtility
 from zope.formlib import form
+from zope.i18n import translate
 from zope.interface import Interface
 from zope.interface import implements
 
@@ -47,34 +53,38 @@ class SetFieldActionExecutor(object):
         self.event = event
 
     def __call__(self):
-        obj = self.event.object
-        value_script = getattr(self.element, 'value_script', False)
+        self.obj = self.event.object
+        self.value_script = getattr(self.element, 'value_script', False)
+        self.update_all = getattr(self.element, 'update_all_content', False)
+        self.conditions = self.get_conditions()
+        self.portal = api.portal.get()
 
-        # Provide the current workflow state of the context
-        state = ''
-        wft = self.context.portal_workflow
-        cur_wf = wft.getWorkflowsFor(obj)
-        if len(cur_wf) > 0:
-            cur_wf = cur_wf[0].id
-            state = wft.getStatusOf(cur_wf, obj)['review_state']
-
-        cp = PyScript(value_script)
-        cp_globals = dict(context=obj,
-                          state=state,
-                          workflow=wft,
-                          history={i: obj.workflow_history[i] for i in
-                                   obj.workflow_history},
-                          event=self.event,
-                          values={})
         try:
-            script = cp.execute(cp_globals)
+            objects = self.get_objects()
         except Exception as e:
-            self.error(obj, e)
+            self.error(self.obj, e)
             return False
 
-        for v_key, value in script['values'].iteritems():
-            logger.info('Setting %s to %s for %s' % (v_key, value, obj.id))
-            setattr(obj, v_key, value)
+        for item in objects:
+            # Test the object against the conditions before updating
+            passing = True
+            if item != self.obj:
+                self.event.object = item
+                for condition in self.conditions:
+                    executable = getMultiAdapter((item, condition, self.event),
+                                                 IExecutable)
+                    if not executable():
+                        passing = False
+                        break
+                if passing is False:
+                    logger.warning('Not executing setField action on %s' % item)
+                    continue
+
+            try:
+                self.process_script(item)
+            except Exception as e:
+                self.error(self.obj, e)
+                return False
 
         return True
 
@@ -86,6 +96,79 @@ class SetFieldActionExecutor(object):
         logger.error(message)
         if self.request is not None:
             IStatusMessage(self.request).addStatusMessage(message, type="error")
+
+    def get_conditions(self):
+        """ Returns the rules conditions for the executing action"""
+        rules = queryUtility(IRuleStorage)
+        rule = None
+        for rule in rules.values():
+            if self.element in rule.actions:
+                break
+        if not rule:
+            raise Exception("Can't find rule for action %s"
+                            % self.element.id)
+        return rule.conditions
+
+    def get_objects(self):
+        query = {}
+        if self.update_all is None or self.update_all == 'object':
+            query['UID'] = IUUID(self.obj)
+
+        if self.update_all and self.update_all == 'all':
+            # Build query based on rule conditions. Each resulting item has
+            # its rule checked, so the search can return extra items.
+            portal_types = getToolByName(self.portal, 'portal_types')
+            for condition in self.conditions:
+                # content type
+                if condition.element == 'plone.conditions.PortalType':
+                    titles = []
+                    for name in condition.check_types:
+                        fti = getattr(portal_types, name, None)
+                        if fti is not None:
+                            title = translate(fti.Title(),
+                                              context=self.portal.REQUEST)
+                            titles.append(title)
+                    query['Type'] = titles
+                # TODO: file extension
+                # TODO: user group
+                # TODO: user role
+                # TODO: workflow state
+                # TODO: workflow transition
+
+        logger.info('Searching with query: %s' % str(query))
+        catalog = self.portal.portal_catalog
+        object_search = catalog.search(query)
+        return [brain.getObject() for brain in object_search]
+
+    def process_script(self, item):
+        state = ''
+        wft = self.context.portal_workflow
+        cur_wf = wft.getWorkflowsFor(item)
+        if len(cur_wf) > 0:
+            cur_wf = cur_wf[0].id
+            state = wft.getStatusOf(cur_wf, item)['review_state']
+
+        history = getattr(item, 'workflow_history', {})
+        if len(history):
+            history = {i: item.workflow_history[i] for i in
+                       item.workflow_history}
+        cp = PyScript(self.value_script)
+        cp_globals = dict(context=item,
+                          state=state,
+                          workflow=wft,
+                          history=history,
+                          event=self.event,
+                          values={})
+        script = cp.execute(cp_globals)
+        item_updated = False
+        for v_key, value in script['values'].iteritems():
+            if value is None and getattr(item, v_key, None) is None:
+                continue
+            logger.info('Setting %s to %s for %s' % (v_key, value, item.id))
+            setattr(item, v_key, value)
+            item_updated = True
+        if item_updated:
+            item.reindexObject()
 
 
 class SetFieldAddForm(AddForm):

--- a/collective/contentrules/setfield/action.py
+++ b/collective/contentrules/setfield/action.py
@@ -1,7 +1,6 @@
 # -*- coding:utf-8 -*-
 from logging import getLogger
 
-
 from OFS.SimpleItem import SimpleItem
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import utils
@@ -9,7 +8,6 @@ from Products.statusmessages.interfaces import IStatusMessage
 from collective.contentrules.setfield import SetFieldMessageFactory as _
 from collective.contentrules.setfield.interfaces import ISetFieldAction
 from collective.contentrules.setfield.restricted import PyScript
-
 from plone.app.contentrules.browser.formhelper import AddForm
 from plone.app.contentrules.browser.formhelper import EditForm
 from plone import api
@@ -79,7 +77,8 @@ class SetFieldActionExecutor(object):
                         passing = False
                         break
                 if passing is False:
-                    logger.warning('Not executing setField action on %s' % item)
+                    logger.warning('Not executing setField action on %s'
+                                   % item)
                     continue
 
             try:
@@ -111,7 +110,8 @@ class SetFieldActionExecutor(object):
                                                              error))
         logger.error(message)
         if self.request is not None:
-            IStatusMessage(self.request).addStatusMessage(message, type="error")
+            IStatusMessage(self.request).addStatusMessage(message,
+                                                          type="error")
 
     def warn(self, url, warning):
         message = _(u"Unable to update %s - %s: %s" % (url,
@@ -208,7 +208,8 @@ class SetFieldAddForm(AddForm):
     """
     form_fields = form.FormFields(ISetFieldAction)
     label = _(u"Add a Set Field Value Action")
-    description = _(u"An action for setting the value of a field on an object.")
+    description = \
+        _(u"An action for setting the value of a field on an object.")
     schema = ISetFieldAction
 
     def create(self, data):
@@ -222,5 +223,6 @@ class SetFieldEditForm(EditForm):
     """
     form_fields = form.FormFields(ISetFieldAction)
     label = _(u"Edit a Move to Field Action")
-    description = _(u"An action for setting the value of a field on an object.")
+    description \
+        = _(u"An action for setting the value of a field on an object.")
     schema = ISetFieldAction

--- a/collective/contentrules/setfield/interfaces.py
+++ b/collective/contentrules/setfield/interfaces.py
@@ -1,9 +1,16 @@
 from collective.contentrules.setfield import SetFieldMessageFactory as _
+from plone.supermodel import model
 from zope import schema
-from zope.interface import Interface
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
 
+items = [
+            ('', u'Select'),
+            ('object', u'Just the object'),
+            ('all', u'All matching objects')]
+terms = [ SimpleTerm(value=pair[0], token=pair[0], title=pair[1]) for pair in items ]
 
-class ISetFieldAction(Interface):
+class ISetFieldAction(model.Schema):
 
     value_script = schema.Text(
 
@@ -13,3 +20,22 @@ class ISetFieldAction(Interface):
                       u"variables are: context, state, history, event"),
         default=_(u"""# values = {'field': some_value}"""),
         required=True)
+
+    update_all_content = schema.Choice(
+        title=_("Update all content?"),
+        description=_(u""),
+        vocabulary=SimpleVocabulary(terms)
+    )
+
+    model.fieldset(
+        'script',
+        label=_(u"Script"),
+        fields=['value_script']
+    )
+
+    model.fieldset(
+        'advanced',
+        label=_(u"Advanced"),
+        fields=['update_all_content']
+
+    )

--- a/collective/contentrules/setfield/interfaces.py
+++ b/collective/contentrules/setfield/interfaces.py
@@ -4,11 +4,12 @@ from zope import schema
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
-items = [
-            ('', u'Select'),
-            ('object', u'Just the object'),
-            ('all', u'All matching objects')]
-terms = [ SimpleTerm(value=pair[0], token=pair[0], title=pair[1]) for pair in items ]
+items = [('', u'Select'),
+         ('object', u'Just the object'),
+         ('all', u'All matching objects')]
+terms = [SimpleTerm(value=pair[0], token=pair[0], title=pair[1])
+         for pair in items]
+
 
 class ISetFieldAction(model.Schema):
 
@@ -21,7 +22,7 @@ class ISetFieldAction(model.Schema):
         default=_(u"""# values = {'field': some_value}"""),
         required=True)
 
-    update_all_content = schema.Choice(
+    update_all = schema.Choice(
         title=_("Update all content?"),
         description=_(u""),
         vocabulary=SimpleVocabulary(terms)
@@ -36,6 +37,6 @@ class ISetFieldAction(model.Schema):
     model.fieldset(
         'advanced',
         label=_(u"Advanced"),
-        fields=['update_all_content']
+        fields=['update_all']
 
     )


### PR DESCRIPTION
# Example Scenario

You have a content rule to change a fields value when a workflow transition is fired. The content rule fetches information from the workflow history and sets it on the object.

This idea would give the rule creator options as to whether the same value should be applied on all content that matches.

#Options

 - match by workflow state. Eg if rule acts on published content then all site content that is published will have the rule executed on it.
 - check event conditions to filter the content that is matched by the rule
 - run conditions against objects to ensure the action should be executed

# Outstanding tasks

 - [ ] Provide description on option when adding action to rule
 - [ ] Filter query on other rule conditions (#todo in code)
 - [ ] Remove debug logging