### PR TITLE
Only reindex item if values have been updated

### DIFF
--- a/collective/contentrules/setfield/action.py
+++ b/collective/contentrules/setfield/action.py
@@ -206,8 +206,9 @@ class SetFieldActionExecutor(object):
         for v_key, value in script['values'].iteritems():
             if value is None and getattr(item, v_key, None) is None:
                 continue
-            setattr(item, v_key, value)
-            item_updated = True
+            if getattr(item, v_key) != value:
+                setattr(item, v_key, value)
+                item_updated = True
         if item_updated:
             item.reindexObject()
 


### PR DESCRIPTION
It's likely that the setfield script can execute but the values on the object remain unchanged. Reindexing an object with unchanged values creates unnecessary overhead.

This PR checks the value is being changed before reindexing the object.