### PR TITLE
Fixed running content rules when using the update all option instead of the object that triggered the content rule

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed running setfield when using the `update_all` option instead of the object that triggered the content rule #27 [JeffersonBledsoe]
 
 
 0.9.0 (2021-07-27)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -17,6 +17,7 @@ recipe = plone.recipe.codeanalysis[recommended]
 directory = ${buildout:directory}/${:source-folder}
 flake8-ignore = Q000, T000, P001, S001, C101, I002, W503
 flake8-exclude = ${:source-folder}/tests, ${:source-folder}/testing.py
+flake8-max-line-length = 88
 pre-commit-hook = False
 debug-statements = True
 deprecated-aliases = True

--- a/collective/contentrules/setfield/action.py
+++ b/collective/contentrules/setfield/action.py
@@ -205,7 +205,7 @@ class SetFieldActionExecutor(object):
         try:
             script = cp.execute(cp_globals)
         except Exception as e:  # noqa:B902
-            self.error(self.obj, e)
+            self.error(item, e)
             return False
 
         fields = self._get_fields(item)
@@ -219,7 +219,7 @@ class SetFieldActionExecutor(object):
             # TODO: should validate against the content type otherwise
             #   this is a security problem
             if v_key not in fields:
-                self.error(self.obj, "Field '%s' not found so not set" % v_key)
+                self.error(item, "Field '%s' not found so not set" % v_key)
                 continue
 
             schema, field = fields[v_key]
@@ -231,7 +231,7 @@ class SetFieldActionExecutor(object):
                     continue
                 error = field.validate(value, item)
                 if error:
-                    self.error(self.obj, str(error))
+                    self.error(item, str(error))
                     continue
                 field.set(item, value)
                 item_updated = True
@@ -242,7 +242,7 @@ class SetFieldActionExecutor(object):
             if dm.get() == value:
                 continue
             if dm is None or not dm.canWrite():
-                self.error(self.obj, "Not able to write %s" % v_key)
+                self.error(item, "Not able to write %s" % v_key)
                 continue
             # TODO: Could also check permission to write however should
             #   be checked against owner for content rule not current user.
@@ -252,14 +252,14 @@ class SetFieldActionExecutor(object):
             try:
                 bound.validate(value)
             except ValidationError as e:
-                self.error(self.obj, str(e))
+                self.error(item, str(e))
                 continue
 
             try:
                 dm.set(value)
                 item_updated = True
             except Exception as e:  # noqa:B902
-                self.error(self.obj, "Error setting %s: %s" % (v_key, str(e)))
+                self.error(item, "Error setting %s: %s" % (v_key, str(e)))
         if item_updated:
             # TODO: shouldn't it reindex just the indexes for
             #   whats changed (and SearchableText)?

--- a/collective/contentrules/setfield/action.py
+++ b/collective/contentrules/setfield/action.py
@@ -113,11 +113,11 @@ class SetFieldActionExecutor(object):
 
     def error(self, obj_being_processed, error):
         title = utils.pretty_title_or_id(
-            obj_being_processed, obj_being_processed
+            obj_being_processed, obj_being_processed,
         )
         message = _(
             u"Unable to set values on %s: %s, %s"
-            % (title, str(type(error)), error)
+            % (title, str(type(error)), error),
         )
         logger.error(message)
         if self.request is not None:

--- a/collective/contentrules/setfield/action.py
+++ b/collective/contentrules/setfield/action.py
@@ -13,7 +13,7 @@ from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.utils import iterSchemata
 from Products.ATContentTypes.interfaces import IATContentType
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone import utils
+from Products.CMFPlone.utils import pretty_title_or_id
 from Products.statusmessages.interfaces import IStatusMessage
 from z3c.form.interfaces import IDataManager
 from zope.component import (adapts, getMultiAdapter, queryMultiAdapter,
@@ -112,7 +112,7 @@ class SetFieldActionExecutor(object):
         return True
 
     def error(self, obj_being_processed, error):
-        title = utils.pretty_title_or_id(
+        title = pretty_title_or_id(
             obj_being_processed, obj_being_processed,
         )
         message = _(

--- a/collective/contentrules/setfield/action.py
+++ b/collective/contentrules/setfield/action.py
@@ -111,8 +111,8 @@ class SetFieldActionExecutor(object):
 
         return True
 
-    def error(self, obj, error):
-        title = utils.pretty_title_or_id(obj, obj)
+    def error(self, obj_being_processed, error):
+        title = utils.pretty_title_or_id(obj_being_processed, obj_being_processed)
         message = _(u"Unable to set values on %s: %s, %s" % (title,
                                                              str(type(error)),
                                                              error))

--- a/collective/contentrules/setfield/action.py
+++ b/collective/contentrules/setfield/action.py
@@ -112,14 +112,16 @@ class SetFieldActionExecutor(object):
         return True
 
     def error(self, obj_being_processed, error):
-        title = utils.pretty_title_or_id(obj_being_processed, obj_being_processed)
-        message = _(u"Unable to set values on %s: %s, %s" % (title,
-                                                             str(type(error)),
-                                                             error))
+        title = utils.pretty_title_or_id(
+            obj_being_processed, obj_being_processed
+        )
+        message = _(
+            u"Unable to set values on %s: %s, %s"
+            % (title, str(type(error)), error)
+        )
         logger.error(message)
         if self.request is not None:
-            IStatusMessage(self.request).addStatusMessage(message,
-                                                          type="error")
+            IStatusMessage(self.request).addStatusMessage(message, type="error")
 
     def warn(self, url, warning):
         message = _(u"Unable to update %s - %s: %s" % (url,

--- a/collective/contentrules/setfield/action.py
+++ b/collective/contentrules/setfield/action.py
@@ -90,7 +90,7 @@ class SetFieldActionExecutor(object):
             old_date = None
             if self.preserve_modification_date is True:
                 old_date = item.modification_date
-            result = self.process_script(item)
+            self.process_script(item)
             if self.preserve_modification_date is True:
                 item.modification_date = old_date
                 item.reindexObject(idxs='modified')

--- a/collective/contentrules/setfield/action.py
+++ b/collective/contentrules/setfield/action.py
@@ -94,7 +94,6 @@ class SetFieldActionExecutor(object):
             if self.preserve_modification_date is True:
                 item.modification_date = old_date
                 item.reindexObject(idxs='modified')
-            return result
 
         # If there are < 5 warnings, display them as messages. Otherwise we
         # set a more generic message & point the user to the zope logs.


### PR DESCRIPTION
This PR removes an unwanted early return to fix processing multiple objects. The error messages have also been updated to show the erroring object as the item being processed instead of the item which triggered the content rule